### PR TITLE
[fix] fix bugs about from_dict function

### DIFF
--- a/streamlit_chatbox/messages.py
+++ b/streamlit_chatbox/messages.py
@@ -248,6 +248,7 @@ class ChatBox:
                 msg = {
                     "role": h["role"],
                     "elements": [OutputElement.from_dict(y) for y in h["elements"]],
+                    "metadata": h["metadata"],
                     }
                 self.other_history(name).append(msg)
 


### PR DESCRIPTION
This bugs do these things:
- fix bugs about ChatBox's from_dict function
- The metadata attribute is added to the history record to prevent exceptions caused by the absence of metadata attributes in output_messages.